### PR TITLE
Fixed password reset logic by adding password confirmation

### DIFF
--- a/reset-password.css
+++ b/reset-password.css
@@ -9,6 +9,6 @@ form {
     text-align: start;
 }
 
-#password {
+#password, #confirm-password {
     margin-bottom: .5em;
 }

--- a/reset-password.html
+++ b/reset-password.html
@@ -59,6 +59,10 @@
                 <br />
                 <input id="password" type="password" required />
                 <br />
+                <label for="confirm-password">Confirm Password</label>
+                <br />
+                <input id="confirm-password" type="password" required />
+                <br />
                 <button type="submit">Submit</button>
             </form>
         </div>

--- a/reset-password.js
+++ b/reset-password.js
@@ -1,9 +1,18 @@
 document.getElementById("reset-password-form").addEventListener("submit", (e) => {
     e.preventDefault();
+    
+    const password = document.getElementById("password").value;
+    const confirmPassword = document.getElementById("confirm-password").value;
+
+    if (password !== confirmPassword) {
+        alert("Passwords do not match.");
+        return;
+    }
+
     const token = new URLSearchParams(window.location.search).get("token");
     fetch("https://play.retro-mmo.com/reset-password", {
         body: JSON.stringify({
-            password: document.getElementById("password").value,
+            password,
             token
         }),
         headers: {


### PR DESCRIPTION
### Summary
This pull request fixes the password reset logic by adding a password confirmation field. The form now requires the user to enter the new password twice and checks if the passwords match before submitting the form.

### Changes
- Added a `confirm-password` input field to the HTML form.
- Updated CSS to style the new input field.
- Modified JS to check if the passwords match before submitting the form.

### Error Handling
**Case 1: Confirm Password is left blank**

![Case 1](https://i.ibb.co/mhNghjd/mustfill-out.png)

**Case 2: Passwords Do not match**

![Case 2](https://i.ibb.co/98kjqvN/passwords-do-not-match.png)

### Issue
This pull request addresses issue #3 "Confirm password field for password reset"
