### PR TITLE
leaderboards pagination logic

### DIFF
--- a/leaderboards.css
+++ b/leaderboards.css
@@ -1,13 +1,27 @@
 @import "./global.css";
 
-table tbody tr:first-child td:nth-child(2) {
-    color: #ffbb31;
+.pagination-button {
+    margin-right: 5px;
 }
 
-table tbody tr:nth-child(2) td:nth-child(2) {
-    color: #a8a8a8;
+.pagination-label {
+    margin-left: 10px;
+    margin-right: 5px;
 }
 
-table tbody tr:nth-child(3) td:nth-child(2) {
-    color: #ad4e1a;
+.pagination-input {
+    width: 50px;
+    padding: 2px;
+    text-align: center;
+    border-radius: 15px; 
+    background-color: #595956; 
+    border: none;
+    color: white;
+}
+
+#pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 10px;
 }

--- a/leaderboards.html
+++ b/leaderboards.html
@@ -69,6 +69,7 @@
             </thead>
             <tbody></tbody>
         </table>
+        <div id="pagination"></div>
     </main>
     <footer>
         <p id="ownership">RetroMMO<sup>®</sup> is created by <a href="https://evanmmo.com" target="_blank">Evan Norton</a>.</p>

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -92,7 +92,7 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
                 if (error.message === 'No more results') {
                     const message = document.createElement('p');
                     message.innerText = 'No more results';
-                    message.style.color = 'yellow';
+                    message.style.color = '#ffe737';
                     const mainElement = document.querySelector('main');
                     mainElement.insertBefore(message, document.getElementById('pagination'));
                     document.getElementById('next-button').innerText = 'Back to start';

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -98,5 +98,5 @@ const updateLeaderboards = () => {
         });
 }
 
-updateLeaderboards();
 createPagination();
+updateLeaderboards();

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -7,7 +7,6 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
     const entries = constants["leaderboards-entries"];
     const entriesPerPage = constants["leaderboards-entries-per-page"];
     const lastPage = Math.ceil(entries / entriesPerPage);
-    console.log(lastPage);
 
     const createPagination = () => {
         const pagination = document.createElement("div");

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -1,11 +1,13 @@
 const urlParams = new URLSearchParams(window.location.search);
 const page = parseInt(urlParams.get('page')) || 1;
 
-fetch("https://play.retro-mmo.com/constants.json").then((res) => {
+fetch("http://localhost:3000/constants.json").then((res) => {
     return res.json();
 }).then((constants) => {
     const entries = constants['leaderboards-entries'];
     const entriesPerPage = constants['leaderboards-entries-per-page'];
+    const lastPage = Math.ceil(entries / entriesPerPage);
+    console.log(lastPage);
 
     const createPagination = () => {
         const pagination = document.createElement('div');
@@ -21,13 +23,16 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
             pagination.appendChild(prevButton);
         }
 
-        const nextButton = document.createElement('button');
-        nextButton.id = 'next-button';
-        nextButton.innerText = 'Next';
-        nextButton.className = 'pagination-button';
-        nextButton.onclick = () => {
-            window.location.search = `?page=${page + 1}`;
-        };
+        if (page < lastPage) {
+            const nextButton = document.createElement('button');
+            nextButton.id = 'next-button';
+            nextButton.innerHTML = '&#8594;';
+            nextButton.className = 'pagination-button';
+            nextButton.onclick = () => {
+                window.location.search = `?page=${page + 1}`;
+            };
+            pagination.appendChild(nextButton);
+        }
 
         const pageInputLabel = document.createElement('label');
         pageInputLabel.innerText = 'Page: ';
@@ -38,7 +43,7 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
         pageInput.id = 'page-input';
         pageInput.type = 'number';
         pageInput.min = 1;
-        pageInput.max = Math.ceil(entries / entriesPerPage);
+        pageInput.max = lastPage;
         pageInput.value = page;
         pageInput.className = 'pagination-input';
         pageInput.onchange = () => {
@@ -48,7 +53,6 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
             }
         };
 
-        pagination.appendChild(nextButton);
         pagination.appendChild(pageInputLabel);
         pagination.appendChild(pageInput);
         document.querySelector('main').appendChild(pagination);

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -1,95 +1,102 @@
 const urlParams = new URLSearchParams(window.location.search);
 const page = parseInt(urlParams.get('page')) || 1;
 
-fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
-    .then((res) => {
-        if (!res.ok) {
-            throw new Error('No more results');
-        }
-        return res.json();
-    })
-    .then((rows) => {
-        const tbody = document.querySelector("table tbody");
-        tbody.innerHTML = ''; // Clear previous rows
-        rows.forEach(({ experience, username }, key) => {
-            const tr = document.createElement("tr");
-            const td1 = document.createElement("td");
-            td1.innerText = ((page - 1) * rows.length + (key + 1)).toLocaleString(); // Adjust numbering based on page
-            const td2 = document.createElement("td");
-            td2.innerText = username;
-            const td3 = document.createElement("td");
-            td3.innerText = experience.toLocaleString();
-            tr.appendChild(td1);
-            tr.appendChild(td2);
-            tr.appendChild(td3);
-            tbody.appendChild(tr);
-        });
+const createPagination = () => {
+    const pagination = document.createElement('div');
+    pagination.id = 'pagination';
 
-        if (page === 1) {
-            const rowsArray = Array.from(tbody.querySelectorAll('tr'));
-            if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
-            if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
-            if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
-        }
+    if (page > 1) {
+        const prevButton = document.createElement('button');
+        prevButton.innerHTML = '&#8592;'; // Arrow symbol
+        prevButton.className = 'pagination-button';
+        prevButton.onclick = () => {
+            window.location.search = `?page=${page - 1}`;
+        };
+        pagination.appendChild(prevButton);
+    }
 
-        document.getElementById("leaderboards").removeAttribute("hidden");
-    })
-    .catch((error) => {
-        if (error.message === 'No more results') {
-            const message = document.createElement('p');
-            message.innerText = 'No more results';
-            message.style.color = 'yellow'; 
-            const mainElement = document.querySelector('main');
-            mainElement.insertBefore(message, document.getElementById('pagination'));
-            document.getElementById('next-button').innerText = 'Back to start';
-            document.getElementById('next-button').onclick = () => {
-                window.location.search = `?page=1`;
-            };
-        } else {
-            console.error('An error occurred:', error);
-        }
-    });
-
-const pagination = document.createElement('div');
-pagination.id = 'pagination';
-
-if (page > 1) {
-    const prevButton = document.createElement('button');
-    prevButton.innerHTML = '&#8592;'; // Arrow symbol
-    prevButton.className = 'pagination-button';
-    prevButton.onclick = () => {
-        window.location.search = `?page=${page - 1}`;
+    const nextButton = document.createElement('button');
+    nextButton.id = 'next-button';
+    nextButton.innerText = 'Next';
+    nextButton.className = 'pagination-button';
+    nextButton.onclick = () => {
+        window.location.search = `?page=${page + 1}`;
     };
-    pagination.appendChild(prevButton);
+
+    const pageInputLabel = document.createElement('label');
+    pageInputLabel.innerText = 'Page: ';
+    pageInputLabel.setAttribute('for', 'page-input');
+    pageInputLabel.className = 'pagination-label';
+
+    const pageInput = document.createElement('input');
+    pageInput.id = 'page-input';
+    pageInput.type = 'number';
+    pageInput.min = 1;
+    pageInput.value = page;
+    pageInput.className = 'pagination-input';
+    pageInput.onchange = () => {
+        const inputPage = parseInt(pageInput.value);
+        if (inputPage > 0) {
+            window.location.search = `?page=${inputPage}`;
+        }
+    };
+
+    pagination.appendChild(nextButton);
+    pagination.appendChild(pageInputLabel);
+    pagination.appendChild(pageInput);
+    document.querySelector('main').appendChild(pagination);
+};
+
+const updateLeaderboards = () => {
+    fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
+        .then((res) => {
+            if (!res.ok) {
+                throw new Error('No more results');
+            }
+            return res.json();
+        })
+        .then((rows) => {
+            const tbody = document.querySelector("table tbody");
+            tbody.innerHTML = ''; // Clear previous rows
+            rows.forEach(({ experience, username }, key) => {
+                const tr = document.createElement("tr");
+                const td1 = document.createElement("td");
+                td1.innerText = ((page - 1) * rows.length + (key + 1)).toLocaleString(); // Adjust numbering based on page
+                const td2 = document.createElement("td");
+                td2.innerText = username;
+                const td3 = document.createElement("td");
+                td3.innerText = experience.toLocaleString();
+                tr.appendChild(td1);
+                tr.appendChild(td2);
+                tr.appendChild(td3);
+                tbody.appendChild(tr);
+            });
+
+            if (page === 1) {
+                const rowsArray = Array.from(tbody.querySelectorAll('tr'));
+                if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
+                if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
+                if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
+            }
+
+            document.getElementById("leaderboards").removeAttribute("hidden");
+        })
+        .catch((error) => {
+            if (error.message === 'No more results') {
+                const message = document.createElement('p');
+                message.innerText = 'No more results';
+                message.style.color = 'yellow';
+                const mainElement = document.querySelector('main');
+                mainElement.insertBefore(message, document.getElementById('pagination'));
+                document.getElementById('next-button').innerText = 'Back to start';
+                document.getElementById('next-button').onclick = () => {
+                    window.location.search = `?page=1`;
+                };
+            } else {
+                console.error('An error occurred:', error);
+            }
+        });
 }
 
-const nextButton = document.createElement('button');
-nextButton.id = 'next-button';
-nextButton.innerText = 'Next';
-nextButton.className = 'pagination-button';
-nextButton.onclick = () => {
-    window.location.search = `?page=${page + 1}`;
-};
-
-const pageInputLabel = document.createElement('label');
-pageInputLabel.innerText = 'Page: ';
-pageInputLabel.setAttribute('for', 'page-input');
-pageInputLabel.className = 'pagination-label';
-
-const pageInput = document.createElement('input');
-pageInput.id = 'page-input';
-pageInput.type = 'number';
-pageInput.min = 1;
-pageInput.value = page;
-pageInput.className = 'pagination-input';
-pageInput.onchange = () => {
-    const inputPage = parseInt(pageInput.value);
-    if (inputPage > 0) {
-        window.location.search = `?page=${inputPage}`;
-    }
-};
-
-pagination.appendChild(nextButton);
-pagination.appendChild(pageInputLabel);
-pagination.appendChild(pageInput);
-document.querySelector('main').appendChild(pagination);
+updateLeaderboards();
+createPagination();

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -1,102 +1,111 @@
 const urlParams = new URLSearchParams(window.location.search);
 const page = parseInt(urlParams.get('page')) || 1;
 
-const createPagination = () => {
-    const pagination = document.createElement('div');
-    pagination.id = 'pagination';
+fetch("https://play.retro-mmo.com/constants.json").then((res) => {
+    return res.json();
+}).then((constants) => {
+    const entries = constants['leaderboards-entries'];
+    const entriesPerPage = constants['leaderboards-entries-per-page'];
 
-    if (page > 1) {
-        const prevButton = document.createElement('button');
-        prevButton.innerHTML = '&#8592;'; // Arrow symbol
-        prevButton.className = 'pagination-button';
-        prevButton.onclick = () => {
-            window.location.search = `?page=${page - 1}`;
+    const createPagination = () => {
+        const pagination = document.createElement('div');
+        pagination.id = 'pagination';
+
+        if (page > 1) {
+            const prevButton = document.createElement('button');
+            prevButton.innerHTML = '&#8592;'; // Arrow symbol
+            prevButton.className = 'pagination-button';
+            prevButton.onclick = () => {
+                window.location.search = `?page=${page - 1}`;
+            };
+            pagination.appendChild(prevButton);
+        }
+
+        const nextButton = document.createElement('button');
+        nextButton.id = 'next-button';
+        nextButton.innerText = 'Next';
+        nextButton.className = 'pagination-button';
+        nextButton.onclick = () => {
+            window.location.search = `?page=${page + 1}`;
         };
-        pagination.appendChild(prevButton);
+
+        const pageInputLabel = document.createElement('label');
+        pageInputLabel.innerText = 'Page: ';
+        pageInputLabel.setAttribute('for', 'page-input');
+        pageInputLabel.className = 'pagination-label';
+
+        const pageInput = document.createElement('input');
+        pageInput.id = 'page-input';
+        pageInput.type = 'number';
+        pageInput.min = 1;
+        pageInput.max = Math.ceil(entries / entriesPerPage);
+        pageInput.value = page;
+        pageInput.className = 'pagination-input';
+        pageInput.onchange = () => {
+            const inputPage = parseInt(pageInput.value);
+            if (inputPage > 0) {
+                window.location.search = `?page=${inputPage}`;
+            }
+        };
+
+        pagination.appendChild(nextButton);
+        pagination.appendChild(pageInputLabel);
+        pagination.appendChild(pageInput);
+        document.querySelector('main').appendChild(pagination);
+    };
+
+    const updateLeaderboards = () => {
+        fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error('No more results');
+                }
+                return res.json();
+            })
+            .then((rows) => {
+                const tbody = document.querySelector("table tbody");
+                tbody.innerHTML = ''; // Clear previous rows
+                rows.forEach(({ experience, username }, key) => {
+                    const tr = document.createElement("tr");
+                    const td1 = document.createElement("td");
+                    td1.innerText = ((page - 1) * rows.length + (key + 1)).toLocaleString(); // Adjust numbering based on page
+                    const td2 = document.createElement("td");
+                    td2.innerText = username;
+                    const td3 = document.createElement("td");
+                    td3.innerText = experience.toLocaleString();
+                    tr.appendChild(td1);
+                    tr.appendChild(td2);
+                    tr.appendChild(td3);
+                    tbody.appendChild(tr);
+                });
+
+                if (page === 1) {
+                    const rowsArray = Array.from(tbody.querySelectorAll('tr'));
+                    if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
+                    if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
+                    if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
+                }
+
+                document.getElementById("leaderboards").removeAttribute("hidden");
+            })
+            .catch((error) => {
+                if (error.message === 'No more results') {
+                    const message = document.createElement('p');
+                    message.innerText = 'No more results';
+                    message.style.color = 'yellow';
+                    const mainElement = document.querySelector('main');
+                    mainElement.insertBefore(message, document.getElementById('pagination'));
+                    document.getElementById('next-button').innerText = 'Back to start';
+                    document.getElementById('next-button').onclick = () => {
+                        window.location.search = `?page=1`;
+                    };
+                } else {
+                    console.error('An error occurred:', error);
+                }
+            });
     }
 
-    const nextButton = document.createElement('button');
-    nextButton.id = 'next-button';
-    nextButton.innerText = 'Next';
-    nextButton.className = 'pagination-button';
-    nextButton.onclick = () => {
-        window.location.search = `?page=${page + 1}`;
-    };
+    createPagination();
+    updateLeaderboards();
+})
 
-    const pageInputLabel = document.createElement('label');
-    pageInputLabel.innerText = 'Page: ';
-    pageInputLabel.setAttribute('for', 'page-input');
-    pageInputLabel.className = 'pagination-label';
-
-    const pageInput = document.createElement('input');
-    pageInput.id = 'page-input';
-    pageInput.type = 'number';
-    pageInput.min = 1;
-    pageInput.value = page;
-    pageInput.className = 'pagination-input';
-    pageInput.onchange = () => {
-        const inputPage = parseInt(pageInput.value);
-        if (inputPage > 0) {
-            window.location.search = `?page=${inputPage}`;
-        }
-    };
-
-    pagination.appendChild(nextButton);
-    pagination.appendChild(pageInputLabel);
-    pagination.appendChild(pageInput);
-    document.querySelector('main').appendChild(pagination);
-};
-
-const updateLeaderboards = () => {
-    fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
-        .then((res) => {
-            if (!res.ok) {
-                throw new Error('No more results');
-            }
-            return res.json();
-        })
-        .then((rows) => {
-            const tbody = document.querySelector("table tbody");
-            tbody.innerHTML = ''; // Clear previous rows
-            rows.forEach(({ experience, username }, key) => {
-                const tr = document.createElement("tr");
-                const td1 = document.createElement("td");
-                td1.innerText = ((page - 1) * rows.length + (key + 1)).toLocaleString(); // Adjust numbering based on page
-                const td2 = document.createElement("td");
-                td2.innerText = username;
-                const td3 = document.createElement("td");
-                td3.innerText = experience.toLocaleString();
-                tr.appendChild(td1);
-                tr.appendChild(td2);
-                tr.appendChild(td3);
-                tbody.appendChild(tr);
-            });
-
-            if (page === 1) {
-                const rowsArray = Array.from(tbody.querySelectorAll('tr'));
-                if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
-                if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
-                if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
-            }
-
-            document.getElementById("leaderboards").removeAttribute("hidden");
-        })
-        .catch((error) => {
-            if (error.message === 'No more results') {
-                const message = document.createElement('p');
-                message.innerText = 'No more results';
-                message.style.color = 'yellow';
-                const mainElement = document.querySelector('main');
-                mainElement.insertBefore(message, document.getElementById('pagination'));
-                document.getElementById('next-button').innerText = 'Back to start';
-                document.getElementById('next-button').onclick = () => {
-                    window.location.search = `?page=1`;
-                };
-            } else {
-                console.error('An error occurred:', error);
-            }
-        });
-}
-
-createPagination();
-updateLeaderboards();

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -1,17 +1,95 @@
-fetch("https://play.retro-mmo.com/leaderboards.json").then((res) => res.json()).then((rows) => {
-    const tbody = document.querySelector("table tbody");
-    rows.forEach(({ experience, username }, key) => {
-        const tr = document.createElement("tr");
-        const td1 = document.createElement("td");
-        td1.innerText = (key + 1).toLocaleString();
-        const td2 = document.createElement("td");
-        td2.innerText = username;
-        const td3 = document.createElement("td");
-        td3.innerText = experience.toLocaleString();
-        tr.appendChild(td1);
-        tr.appendChild(td2);
-        tr.appendChild(td3);
-        tbody.appendChild(tr);
+const urlParams = new URLSearchParams(window.location.search);
+const page = parseInt(urlParams.get('page')) || 1;
+
+fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
+    .then((res) => {
+        if (!res.ok) {
+            throw new Error('No more results');
+        }
+        return res.json();
+    })
+    .then((rows) => {
+        const tbody = document.querySelector("table tbody");
+        tbody.innerHTML = ''; // Clear previous rows
+        rows.forEach(({ experience, username }, key) => {
+            const tr = document.createElement("tr");
+            const td1 = document.createElement("td");
+            td1.innerText = ((page - 1) * rows.length + (key + 1)).toLocaleString(); // Adjust numbering based on page
+            const td2 = document.createElement("td");
+            td2.innerText = username;
+            const td3 = document.createElement("td");
+            td3.innerText = experience.toLocaleString();
+            tr.appendChild(td1);
+            tr.appendChild(td2);
+            tr.appendChild(td3);
+            tbody.appendChild(tr);
+        });
+
+        if (page === 1) {
+            const rowsArray = Array.from(tbody.querySelectorAll('tr'));
+            if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
+            if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
+            if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
+        }
+
+        document.getElementById("leaderboards").removeAttribute("hidden");
+    })
+    .catch((error) => {
+        if (error.message === 'No more results') {
+            const message = document.createElement('p');
+            message.innerText = 'No more results';
+            message.style.color = 'yellow'; 
+            const mainElement = document.querySelector('main');
+            mainElement.insertBefore(message, document.getElementById('pagination'));
+            document.getElementById('next-button').innerText = 'Back to start';
+            document.getElementById('next-button').onclick = () => {
+                window.location.search = `?page=1`;
+            };
+        } else {
+            console.error('An error occurred:', error);
+        }
     });
-    document.getElementById("leaderboards").removeAttribute("hidden");
-});
+
+const pagination = document.createElement('div');
+pagination.id = 'pagination';
+
+if (page > 1) {
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&#8592;'; // Arrow symbol
+    prevButton.className = 'pagination-button';
+    prevButton.onclick = () => {
+        window.location.search = `?page=${page - 1}`;
+    };
+    pagination.appendChild(prevButton);
+}
+
+const nextButton = document.createElement('button');
+nextButton.id = 'next-button';
+nextButton.innerText = 'Next';
+nextButton.className = 'pagination-button';
+nextButton.onclick = () => {
+    window.location.search = `?page=${page + 1}`;
+};
+
+const pageInputLabel = document.createElement('label');
+pageInputLabel.innerText = 'Page: ';
+pageInputLabel.setAttribute('for', 'page-input');
+pageInputLabel.className = 'pagination-label';
+
+const pageInput = document.createElement('input');
+pageInput.id = 'page-input';
+pageInput.type = 'number';
+pageInput.min = 1;
+pageInput.value = page;
+pageInput.className = 'pagination-input';
+pageInput.onchange = () => {
+    const inputPage = parseInt(pageInput.value);
+    if (inputPage > 0) {
+        window.location.search = `?page=${inputPage}`;
+    }
+};
+
+pagination.appendChild(nextButton);
+pagination.appendChild(pageInputLabel);
+pagination.appendChild(pageInput);
+document.querySelector('main').appendChild(pagination);

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -1,22 +1,23 @@
 const urlParams = new URLSearchParams(window.location.search);
-const page = parseInt(urlParams.get('page')) || 1;
+const page = parseInt(urlParams.get("page")) || 1;
 
-fetch("http://localhost:3000/constants.json").then((res) => {
+fetch("https://play.retro-mmo.com/constants.json").then((res) => {
     return res.json();
 }).then((constants) => {
-    const entries = constants['leaderboards-entries'];
-    const entriesPerPage = constants['leaderboards-entries-per-page'];
+    const entries = constants["leaderboards-entries"];
+    const entriesPerPage = constants["leaderboards-entries-per-page"];
     const lastPage = Math.ceil(entries / entriesPerPage);
     console.log(lastPage);
 
     const createPagination = () => {
-        const pagination = document.createElement('div');
-        pagination.id = 'pagination';
+        const pagination = document.createElement("div");
+        pagination.id = "pagination";
 
         if (page > 1) {
-            const prevButton = document.createElement('button');
-            prevButton.innerHTML = '&#8592;'; // Arrow symbol
-            prevButton.className = 'pagination-button';
+            const prevButton = document.createElement("button");
+            prevButton.id = "prev-button";
+            prevButton.innerHTML = "&#8592;"; // Arrow symbol
+            prevButton.className = "pagination-button";
             prevButton.onclick = () => {
                 window.location.search = `?page=${page - 1}`;
             };
@@ -24,28 +25,28 @@ fetch("http://localhost:3000/constants.json").then((res) => {
         }
 
         if (page < lastPage) {
-            const nextButton = document.createElement('button');
-            nextButton.id = 'next-button';
-            nextButton.innerHTML = '&#8594;';
-            nextButton.className = 'pagination-button';
+            const nextButton = document.createElement("button");
+            nextButton.id = "next-button";
+            nextButton.innerHTML = "&#8594;";
+            nextButton.className = "pagination-button";
             nextButton.onclick = () => {
                 window.location.search = `?page=${page + 1}`;
             };
             pagination.appendChild(nextButton);
         }
 
-        const pageInputLabel = document.createElement('label');
-        pageInputLabel.innerText = 'Page: ';
-        pageInputLabel.setAttribute('for', 'page-input');
-        pageInputLabel.className = 'pagination-label';
+        const pageInputLabel = document.createElement("label");
+        pageInputLabel.innerText = "Page: ";
+        pageInputLabel.setAttribute("for", "page-input");
+        pageInputLabel.className = "pagination-label";
 
-        const pageInput = document.createElement('input');
-        pageInput.id = 'page-input';
-        pageInput.type = 'number';
+        const pageInput = document.createElement("input");
+        pageInput.id = "page-input";
+        pageInput.type = "number";
         pageInput.min = 1;
         pageInput.max = lastPage;
         pageInput.value = page;
-        pageInput.className = 'pagination-input';
+        pageInput.className = "pagination-input";
         pageInput.onchange = () => {
             const inputPage = parseInt(pageInput.value);
             if (inputPage > 0) {
@@ -55,20 +56,20 @@ fetch("http://localhost:3000/constants.json").then((res) => {
 
         pagination.appendChild(pageInputLabel);
         pagination.appendChild(pageInput);
-        document.querySelector('main').appendChild(pagination);
+        document.querySelector("main").appendChild(pagination);
     };
 
     const updateLeaderboards = () => {
         fetch(`https://play.retro-mmo.com/leaderboards.json?page=${page}`)
             .then((res) => {
                 if (!res.ok) {
-                    throw new Error('No more results');
+                    throw new Error("No more results");
                 }
                 return res.json();
             })
             .then((rows) => {
                 const tbody = document.querySelector("table tbody");
-                tbody.innerHTML = ''; // Clear previous rows
+                tbody.innerHTML = ""; // Clear previous rows
                 rows.forEach(({ experience, username }, key) => {
                     const tr = document.createElement("tr");
                     const td1 = document.createElement("td");
@@ -84,27 +85,26 @@ fetch("http://localhost:3000/constants.json").then((res) => {
                 });
 
                 if (page === 1) {
-                    const rowsArray = Array.from(tbody.querySelectorAll('tr'));
-                    if (rowsArray[0]) rowsArray[0].children[1].style.color = '#ffbb31'; // Gold
-                    if (rowsArray[1]) rowsArray[1].children[1].style.color = '#a8a8a8'; // Silver
-                    if (rowsArray[2]) rowsArray[2].children[1].style.color = '#ad4e1a'; // Bronze
+                    const rowsArray = Array.from(tbody.querySelectorAll("tr"));
+                    if (rowsArray[0]) rowsArray[0].children[1].style.color = "#ffbb31"; // Gold
+                    if (rowsArray[1]) rowsArray[1].children[1].style.color = "#a8a8a8"; // Silver
+                    if (rowsArray[2]) rowsArray[2].children[1].style.color = "#ad4e1a"; // Bronze
                 }
 
                 document.getElementById("leaderboards").removeAttribute("hidden");
             })
             .catch((error) => {
-                if (error.message === 'No more results') {
-                    const message = document.createElement('p');
-                    message.innerText = 'No more results';
-                    message.style.color = '#ffe737';
-                    const mainElement = document.querySelector('main');
-                    mainElement.insertBefore(message, document.getElementById('pagination'));
-                    document.getElementById('next-button').innerText = 'Back to start';
-                    document.getElementById('next-button').onclick = () => {
-                        window.location.search = `?page=1`;
+                if (error.message === "No more results") {
+                    const message = document.createElement("p");
+                    message.innerText = "No more results";
+                    message.style.color = "#ffe737";
+                    const mainElement = document.querySelector("main");
+                    mainElement.insertBefore(message, document.getElementById("pagination"));
+                    document.getElementById("prev-button").onclick = () => {
+                        window.location.search = "?page=1";
                     };
                 } else {
-                    console.error('An error occurred:', error);
+                    console.error("An error occurred:", error);
                 }
             });
     }


### PR DESCRIPTION
### Contributors
_Credit:_ Thanks to [amthomps11](https://github.com/amthomps11). This is based entirely off their PR. Which added logic for pagination to the leaderboards.

Note -- While integrating the pagination logic from [amthomps11](https://github.com/amthomps11) I got rid of URL redirects in the HTML to leaderboards page 1. As well as added a "no more results" message, a "back to start" button, and the ability for users to type in a page number.

### Summary
Improved pagination functionality on the leaderboards. Allowing users to navigate through pages and enter a page number directly.

### Changes
- Added pagination functionality to the leaderboards.
- Allowed providing a query string on the leaderboards (e.g. `https://retro-mmo.com/leaderboards?page=2`).
- Updated `leaderboards.js` to use the page value in the request (e.g. `https://play.retro-mmo.com/leaderboards.json?page=2`).
- Used JavaScript to apply the gold/silver/bronze colors for 1st/2nd/3rd place)
- Added an input field to allow users to type in a page number.
- Displayed a message and updated buttons when there are no more results.

### Error Handling
**Case 1: No more results**

![No results](https://i.ibb.co/QDryvf1/no-results.png)

### Screenshots
**Pagination with colored top 3**

![gold-Silver](https://i.ibb.co/7tJRJwZ/gold-Silver.png)

**Next button**

![Next-Button](https://i.ibb.co/wsz3yZT/Next-Button.png)

**Back arrow**

![back-Arrow](https://i.ibb.co/fkX3F2m/back-Arrow.png)

**Consistent numbering across pages**

![consistent-numbering](https://i.ibb.co/6wYrVmr/consistent-numbering.png)

### Issue
This pull request addresses issue #5 "Add pagination to leaderboards"
