### PR TITLE
Add pagination to top

### DIFF
--- a/leaderboards.css
+++ b/leaderboards.css
@@ -25,3 +25,80 @@
     justify-content: center;
     margin-top: 10px;
 }
+
+#search-pagination-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#search-bar-container {
+    display: flex;
+    align-items: center;
+}
+
+#search-bar {
+    width: 200px;
+    padding: 5px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    margin-right: 10px;
+    font-size: 26px; 
+}
+
+#search-button {
+    padding: 5px 10px;
+    border-radius: 5px;
+    border: none;
+    background-color: #333;
+    color: white;
+    cursor: pointer;
+}
+
+#search-button:hover {
+    background-color: #555;
+}
+
+#pagination-top,
+#pagination-bottom-container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+#search-results {
+    text-align: left;
+    margin-top: 10px;
+    color: white;
+}
+
+/* Media query for smaller devices */
+@media (max-width: 600px) {
+    #search-pagination-container {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    #search-bar-container {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 10px;
+    }
+
+    #search-bar {
+        width: 140px; /* Adjust for smaller devices */
+        font-size: 20px;
+    }
+
+    #search-button {
+        width: 70px;
+        padding: 5px;
+    }
+
+    /* center pagination at bottom since top will be centered */
+    #pagination-bottom-container {
+        justify-content: center; 
+        margin-top: 10px; 
+    }
+}

--- a/leaderboards.css
+++ b/leaderboards.css
@@ -73,6 +73,39 @@
     color: white;
 }
 
+.search-message {
+    color: #ffffff;
+    text-align: center;
+}
+
+.result-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.search-result {
+    color: white;
+    margin: 0;
+}
+
+/* Button that closes the search results and resets the search */
+.clear-search-button {
+    background-color: #333;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 16px;
+    padding: 5px 10px;
+    margin-left: 10px;
+}
+
+.clear-search-button:hover {
+    background-color: #555;
+}
+
 /* Media query for smaller devices */
 @media (max-width: 600px) {
     #search-pagination-container {
@@ -87,12 +120,12 @@
     }
 
     #search-bar {
-        width: 140px; /* Adjust for smaller devices */
+        width: 140px; /* Adjust as needed for smaller devices */
         font-size: 20px;
     }
 
     #search-button {
-        width: 70px;
+        width: 70px; /* Adjust as needed for smaller devices */
         padding: 5px;
     }
 

--- a/leaderboards.html
+++ b/leaderboards.html
@@ -55,6 +55,7 @@
     </header>
     <main>
         <h1>Leaderboards</h1>
+        <div id="pagination-top"></div>
         <table id="leaderboards" hidden>
             <thead>
                 <tr>
@@ -69,8 +70,9 @@
             </thead>
             <tbody></tbody>
         </table>
-        <div id="pagination"></div>
+        <div id="pagination-bottom"></div>
     </main>
+    
     <footer>
         <p id="ownership">RetroMMO<sup>®</sup> is created by <a href="https://evanmmo.com" target="_blank">Evan Norton</a>.</p>
         <div id="social-links">

--- a/leaderboards.html
+++ b/leaderboards.html
@@ -55,7 +55,14 @@
     </header>
     <main>
         <h1>Leaderboards</h1>
-        <div id="pagination-top"></div>
+        <div id="search-pagination-container">
+            <div id="search-bar-container">
+                <input type="text" id="search-bar" placeholder="Search username..." />
+                <button id="search-button">Search</button>
+            </div>
+            <div id="pagination-top"></div>
+        </div>
+        <div id="search-results"></div>
         <table id="leaderboards" hidden>
             <thead>
                 <tr>
@@ -70,7 +77,9 @@
             </thead>
             <tbody></tbody>
         </table>
-        <div id="pagination-bottom"></div>
+        <div id="pagination-bottom-container">
+            <div id="pagination-bottom"></div>
+        </div>
     </main>
     
     <footer>

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -130,6 +130,17 @@ document.addEventListener("DOMContentLoaded", () => {
             });
     };
 
+    const createClearSearchButton = () => {
+        const clearSearchButton = document.createElement("button");
+        clearSearchButton.innerHTML = "&times;";
+        clearSearchButton.className = "clear-search-button";
+        clearSearchButton.onclick = () => {
+            searchBar.value = '';
+            searchResults.innerHTML = '';
+        };
+        return clearSearchButton;
+    };
+
     const searchLeaderboard = async (query) => {
         //-- RetroMMO BDAY Easter Egg --
         if (query === "08142020") {
@@ -143,14 +154,7 @@ document.addEventListener("DOMContentLoaded", () => {
             result.className = "search-result";
             resultContainer.appendChild(result);
     
-            const clearSearchButton = document.createElement("button");
-            clearSearchButton.innerHTML = "&times;";
-            clearSearchButton.className = "clear-search-button";
-            clearSearchButton.onclick = () => {
-                searchBar.value = '';
-                searchResults.innerHTML = '';
-            };
-    
+            const clearSearchButton = createClearSearchButton();
             resultContainer.appendChild(clearSearchButton);
             searchResults.appendChild(resultContainer);
             return; // Exit the function early
@@ -184,14 +188,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     result.className = "search-result";
                     resultContainer.appendChild(result);
 
-                    const clearSearchButton = document.createElement("button");
-                    clearSearchButton.innerHTML = "&times;";
-                    clearSearchButton.className = "clear-search-button";
-                    clearSearchButton.onclick = () => {
-                        searchBar.value = '';
-                        searchResults.innerHTML = '';
-                    };
-
+                    const clearSearchButton = createClearSearchButton();
                     resultContainer.appendChild(clearSearchButton);
                     searchResults.appendChild(resultContainer);
                     found = true;

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -72,9 +72,6 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
             .then((rows) => {
                 const tbody = document.querySelector("table tbody");
                 tbody.innerHTML = ""; // Clear previous rows
-                if (rows.length === 0) {
-                    throw new Error("No more results");
-                }
                 rows.forEach(({ experience, username }, key) => {
                     const tr = document.createElement("tr");
                     const td1 = document.createElement("td");

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -137,7 +137,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const searchingMessage = document.createElement("p");
         searchingMessage.innerText = "Searching...";
-        searchingMessage.style.color = "#ffffff";
+        searchingMessage.className = "search-message"; // Use CSS class for styling
         searchResults.appendChild(searchingMessage);
 
         while (!found) {
@@ -150,10 +150,25 @@ document.addEventListener("DOMContentLoaded", () => {
                     const index = rows.findIndex(user => user.username === username) + 1 + (page - 1) * rows.length;
 
                     searchResults.innerHTML = ''; // Clear "Searching..." message
+                    const resultContainer = document.createElement("div");
+                    resultContainer.className = "result-container"; 
+
                     const result = document.createElement("p");
                     result.innerHTML = `#${index} ${username} - ${experience.toLocaleString()}`;
                     result.style.color = index === 1 ? "#ffbb31" : index === 2 ? "#a8a8a8" : index === 3 ? "#ad4e1a" : "white";
-                    searchResults.appendChild(result);
+                    result.className = "search-result";
+                    resultContainer.appendChild(result);
+
+                    const clearSearchButton = document.createElement("button");
+                    clearSearchButton.innerHTML = "&times;";
+                    clearSearchButton.className = "clear-search-button";
+                    clearSearchButton.onclick = () => {
+                        searchBar.value = '';
+                        searchResults.innerHTML = '';
+                    };
+
+                    resultContainer.appendChild(clearSearchButton);
+                    searchResults.appendChild(resultContainer);
                     found = true;
                 } else {
                     page++;
@@ -164,13 +179,14 @@ document.addEventListener("DOMContentLoaded", () => {
                     const noResult = document.createElement("p");
                     noResult.innerText = "No results found";
                     noResult.style.color = "#ffe737";
+                    noResult.className = "search-message";
                     searchResults.appendChild(noResult);
                     found = true;
                 } else {
                     console.error("An error occurred:", error);
                     const errorResult = document.createElement("p");
                     errorResult.innerText = "An error occurred while searching";
-                    errorResult.style.color = "#ff0000";
+                    errorResult.className = "search-message";
                     searchResults.appendChild(errorResult);
                     found = true;
                 }

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -131,6 +131,31 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     const searchLeaderboard = async (query) => {
+        //-- RetroMMO BDAY Easter Egg --
+        if (query === "08142020") {
+            searchResults.innerHTML = ''; // Clear previous results
+            const resultContainer = document.createElement("div");
+            resultContainer.className = "result-container"; 
+    
+            const result = document.createElement("p");
+            result.innerHTML = "Happy Birthday RetroMMO!";
+            result.style.color = "#5ba8ff";
+            result.className = "search-result";
+            resultContainer.appendChild(result);
+    
+            const clearSearchButton = document.createElement("button");
+            clearSearchButton.innerHTML = "&times;";
+            clearSearchButton.className = "clear-search-button";
+            clearSearchButton.onclick = () => {
+                searchBar.value = '';
+                searchResults.innerHTML = '';
+            };
+    
+            resultContainer.appendChild(clearSearchButton);
+            searchResults.appendChild(resultContainer);
+            return; // Exit the function early
+        }
+        // -----------
         let page = 1;
         let found = false;
         searchResults.innerHTML = ''; // Clear previous results

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -8,13 +8,17 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
     const entriesPerPage = constants["leaderboards-entries-per-page"];
     const lastPage = Math.ceil(entries / entriesPerPage);
 
-    const createPagination = () => {
+    const createPagination = (containerId) => {
+        const container = document.getElementById(containerId);
         const pagination = document.createElement("div");
-        pagination.id = "pagination";
+        pagination.className = "pagination";
+        
+        if (containerId === 'pagination-bottom') {
+            container.style.display = 'none'; // Initially hide bottom pagination
+        }
 
         if (page > 1) {
             const prevButton = document.createElement("button");
-            prevButton.id = "prev-button";
             prevButton.innerHTML = "&#8592;"; // Arrow symbol
             prevButton.className = "pagination-button";
             prevButton.onclick = () => {
@@ -25,7 +29,6 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
 
         if (page < lastPage) {
             const nextButton = document.createElement("button");
-            nextButton.id = "next-button";
             nextButton.innerHTML = "&#8594;";
             nextButton.className = "pagination-button";
             nextButton.onclick = () => {
@@ -36,11 +39,11 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
 
         const pageInputLabel = document.createElement("label");
         pageInputLabel.innerText = "Page: ";
-        pageInputLabel.setAttribute("for", "page-input");
+        pageInputLabel.setAttribute("for", `${containerId}-page-input`);
         pageInputLabel.className = "pagination-label";
 
         const pageInput = document.createElement("input");
-        pageInput.id = "page-input";
+        pageInput.id = `${containerId}-page-input`;
         pageInput.type = "number";
         pageInput.min = 1;
         pageInput.max = lastPage;
@@ -55,7 +58,7 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
 
         pagination.appendChild(pageInputLabel);
         pagination.appendChild(pageInput);
-        document.querySelector("main").appendChild(pagination);
+        container.appendChild(pagination);
     };
 
     const updateLeaderboards = () => {
@@ -69,6 +72,9 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
             .then((rows) => {
                 const tbody = document.querySelector("table tbody");
                 tbody.innerHTML = ""; // Clear previous rows
+                if (rows.length === 0) {
+                    throw new Error("No more results");
+                }
                 rows.forEach(({ experience, username }, key) => {
                     const tr = document.createElement("tr");
                     const td1 = document.createElement("td");
@@ -91,24 +97,23 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
                 }
 
                 document.getElementById("leaderboards").removeAttribute("hidden");
+                document.getElementById("pagination-bottom").style.display = 'block'; // Show bottom pagination after loading
             })
             .catch((error) => {
                 if (error.message === "No more results") {
                     const message = document.createElement("p");
                     message.innerText = "No more results";
                     message.style.color = "#ffe737";
-                    const mainElement = document.querySelector("main");
-                    mainElement.insertBefore(message, document.getElementById("pagination"));
-                    document.getElementById("prev-button").onclick = () => {
-                        window.location.search = "?page=1";
-                    };
+                    const paginationTop = document.getElementById("pagination-top");
+                    paginationTop.parentNode.insertBefore(message, paginationTop); // Insert message above pagination-top
+                    document.getElementById("pagination-bottom").style.display = 'none';
                 } else {
                     console.error("An error occurred:", error);
                 }
             });
     }
 
-    createPagination();
+    createPagination('pagination-top');
+    createPagination('pagination-bottom');
     updateLeaderboards();
-})
-
+});


### PR DESCRIPTION
### Summary
Improved pagination functionality on the leaderboards.

### Changes
- Added pagination functionality to the top of the leaderboards.
- Moved pagination logic to the right of leaderboards (top right and bottom right).
- Initially hid the bottom pagination until the leaderboard is fully loaded.
- Added search bar

### Screenshots
**Search Bar**
![Search-Bar](https://i.ibb.co/bmG9dFw/Search-Bar.png)

**Search Player**
![Searchplayer](https://i.ibb.co/jVDjd3g/Searchplayer.png)

**Searching Message**
![Searching-Msg](https://i.ibb.co/s6ypKS0/Searching-Msg.png)

**No Results Found**
![noresultsfound](https://i.ibb.co/7NbLBZx/noresultsfound.png)

**Retains Search Color**
![Retains-Search-Color](https://i.ibb.co/6R8H59b/Retains-Search-Color.png)

**Formatted for Mobile**
![Formatted-For-Mobile](https://i.ibb.co/mbtkNs3/Formatted-For-Mobile.png)

### BDAY Easter Egg
Added an easter egg purely for fun to celebrate the birthday of RetroMMO. If the user searches for "08142020", a special message is displayed.

![EasterEggBDAY](https://i.ibb.co/L8k3rkR/Birthday-Easter-Egg.png)

### Issue
This pull request addresses [issue #8](https://github.com/evannorton/Retro-MMO.com/issues/8) "Add pagination to leaderboards"
