### PR TITLE
fixed previous button logic on empty pages + dynamically calculate re…

### DIFF
--- a/leaderboards.js
+++ b/leaderboards.js
@@ -19,6 +19,7 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
 
         if (page > 1) {
             const prevButton = document.createElement("button");
+            prevButton.id = "prev-button";
             prevButton.innerHTML = "&#8592;"; // Arrow symbol
             prevButton.className = "pagination-button";
             prevButton.onclick = () => {
@@ -98,16 +99,20 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
             })
             .catch((error) => {
                 if (error.message === "No more results") {
+                    const totalShownEntries = lastPage * entriesPerPage;
                     const message = document.createElement("p");
-                    message.innerText = "No more results";
+                    message.innerText = `No more results. Only top ${totalShownEntries.toLocaleString()} shown.`;
                     message.style.color = "#ffe737";
                     const paginationTop = document.getElementById("pagination-top");
                     paginationTop.parentNode.insertBefore(message, paginationTop); // Insert message above pagination-top
                     document.getElementById("pagination-bottom").style.display = 'none';
+                    document.getElementById("prev-button").onclick = () => {
+                        window.location.search = `?page=${lastPage}`;
+                    };
                 } else {
                     console.error("An error occurred:", error);
                 }
-            });
+            });                
     }
 
     createPagination('pagination-top');

--- a/leaderboards.js
+++ b/leaderboards.js
@@ -112,7 +112,7 @@ fetch("https://play.retro-mmo.com/constants.json").then((res) => {
                 } else {
                     console.error("An error occurred:", error);
                 }
-            });                
+            });
     }
 
     createPagination('pagination-top');


### PR DESCRIPTION
### Summary
Small fix updating the back button logic to navigate to the highest page when there are no more results. Also new message for page with empty results. This should help with confusion of some players wondering why they are not on the leaderboards.

### Changes
- Fixed the back button logic to navigate to the highest page (last page) when there are no more results.
- Updated the "No more results" message to dynamically calculate and display the total number of entries shown. 

### Screenshots
**No Results New Message**
![No-Results-New-Msg](https://i.ibb.co/qMLgx0w/No-Results-New-Msg.png)

**Back to Highest Page**
![backtohighestpage](https://i.ibb.co/28qw5Jd/backtohighestpage.png)